### PR TITLE
Use `set` to set shell options

### DIFF
--- a/aqua-examples/aqua-ceramic-integration/scripts/build.sh
+++ b/aqua-examples/aqua-ceramic-integration/scripts/build.sh
@@ -1,4 +1,6 @@
-#!/usr/bin/env bash -o errexit -o nounset -o pipefail
+#!/usr/bin/env bash
+
+set -o errexit -o nounset -o pipefail
 
 
 mkdir -p artifacts

--- a/aqua-examples/decentralized-blockchain-gateway/scripts/build.sh
+++ b/aqua-examples/decentralized-blockchain-gateway/scripts/build.sh
@@ -1,4 +1,6 @@
-#!/usr/bin/env bash -o errexit -o nounset -o pipefail
+#!/usr/bin/env bash
+
+set -o errexit -o nounset -o pipefail
 
 mkdir -p artifacts
 rm -f artifacts/*.wasm

--- a/aqua-examples/echo-greeter/utilities/scripts/build.sh
+++ b/aqua-examples/echo-greeter/utilities/scripts/build.sh
@@ -1,4 +1,6 @@
-#!/usr/bin/env bash -o errexit -o nounset -o pipefail
+#!/usr/bin/env bash
+
+set -o errexit -o nounset -o pipefail
 
 mkdir -p artifacts
 rm -f artifacts/*.wasm

--- a/aqua-examples/near-integration/services/scripts/build.sh
+++ b/aqua-examples/near-integration/services/scripts/build.sh
@@ -1,4 +1,6 @@
-#!/usr/bin/env bash -o errexit -o nounset -o pipefail
+#!/usr/bin/env bash
+
+set -o errexit -o nounset -o pipefail
 
 mkdir -p artifacts
 rm -f artifacts/*.wasm

--- a/aqua-examples/price-oracle/scripts/build.sh
+++ b/aqua-examples/price-oracle/scripts/build.sh
@@ -1,4 +1,6 @@
-#!/usr/bin/env bash -o errexit -o nounset -o pipefail
+#!/usr/bin/env bash
+
+set -o errexit -o nounset -o pipefail
 
 mkdir -p artifacts
 

--- a/aqua-examples/ts-oracle/scripts/build.sh
+++ b/aqua-examples/ts-oracle/scripts/build.sh
@@ -1,4 +1,6 @@
-#!/usr/bin/env bash -o errexit -o nounset -o pipefail
+#!/usr/bin/env bash
+
+set -o errexit -o nounset -o pipefail
 
 mkdir -p artifacts
 rm -f artifacts/*.wasm

--- a/quickstart/4-composing-services-with-aqua/adder/scripts/build.sh
+++ b/quickstart/4-composing-services-with-aqua/adder/scripts/build.sh
@@ -1,4 +1,6 @@
-#!/usr/bin/env bash -o errexit -o nounset -o pipefail
+#!/usr/bin/env bash
+
+set -o errexit -o nounset -o pipefail
 cargo update --aggressive
 
 mkdir -p artifacts

--- a/quickstart/5-oracle-service/scripts/build.sh
+++ b/quickstart/5-oracle-service/scripts/build.sh
@@ -1,4 +1,6 @@
-#!/usr/bin/env bash -o errexit -o nounset -o pipefail
+#!/usr/bin/env bash
+
+set -o errexit -o nounset -o pipefail
 
 mkdir -p artifacts
 rm -f artifacts/*.wasm

--- a/quickstart/5-oracle-service/scripts/deploy.sh
+++ b/quickstart/5-oracle-service/scripts/deploy.sh
@@ -1,4 +1,7 @@
-#!/usr/bin/env bash -o errexit -o nounset -o pipefail
+#!/usr/bin/env bash
+
+set -o errexit -o nounset -o pipefail
+
 
 function is_installed {
       if ! command -v "$1" >/dev/null 2>&1; then


### PR DESCRIPTION
This fixes compatibility issues across different execution environments (different shells and OSes). `set` is a widely-supported approach, while passing options directly to shebang is a niche feature.