### PR TITLE
Fix path to artifacts directory

### DIFF
--- a/quickstart/2-hosted-services/configs/Config.toml
+++ b/quickstart/2-hosted-services/configs/Config.toml
@@ -1,4 +1,4 @@
-modules_dir = "artifacts/"
+modules_dir = "../artifacts/"
 
 [[module]]
 name = "hello_world"


### PR DESCRIPTION
Got an error when running `mrepl configs/Config.toml`, because the path to the artifacts directory was wrong.